### PR TITLE
Fix error when path to script contains spaces

### DIFF
--- a/src/awk-csv-parser.sh
+++ b/src/awk-csv-parser.sh
@@ -38,12 +38,12 @@ OUTPUT_SEPARATOR='|'
 IN='-'
 
 # Includes:
-. $ROOT_DIR/src/inc/functions.sh
+. "$ROOT_DIR/src/inc/functions.sh"
 
 # Main:
 getOpts "$@"
 cat $IN | awk \
-    -f $ROOT_DIR/src/csv-parser.awk \
+    -f "$ROOT_DIR/src/csv-parser.awk" \
     -v separator=$SEPARATOR \
     -v enclosure=$ENCLOSURE \
     -v output_separator=$OUTPUT_SEPARATOR \


### PR DESCRIPTION
When the path to `awk-csv-parser.sh` contains spaces, the shell variable [`ROOT_DIR`](https://github.com/agraboso/awk-csv-parser/blob/fix-spaces-in-path/src/awk-csv-parser.sh#L34) contains those spaces. [Trying to run `functions.sh`](https://github.com/agraboso/awk-csv-parser/blob/fix-spaces-in-path/src/awk-csv-parser.sh#L41), as well as the subsequent [`awk` invocation](https://github.com/agraboso/awk-csv-parser/blob/fix-spaces-in-path/src/awk-csv-parser.sh#L46), then fails in the absence of the appropriate double quotes, which this PR adds.